### PR TITLE
Remove nearly invisible text shadow

### DIFF
--- a/templates/layouts/mojolicious.html.ep
+++ b/templates/layouts/mojolicious.html.ep
@@ -42,7 +42,6 @@
         font: 0.9em Consolas, Menlo, Monaco, Courier, monospace;
         line-height: 1.5em;
         text-align: left;
-        text-shadow: #eee 0 1px 0;
         white-space: pre-wrap;
       }
       ul { list-style-type: square }


### PR DESCRIPTION
This causes some oddities in Firefox on Linux when highlighting text on the mojolicious.org domain

![Image of drunken shadows](https://www.simcop2387.info/shadow.png)