### PR TITLE
Remove #version collision

### DIFF
--- a/lib/Mojolicious/Plugin/resources/templates/mojodocs/mojodocs.html.ep
+++ b/lib/Mojolicious/Plugin/resources/templates/mojodocs/mojodocs.html.ep
@@ -81,7 +81,7 @@
       }
       #perldoc > ul:first-of-type a { text-decoration: none }
       #links { padding-bottom: 1em }
-      #version { float: right }
+      #mojo-version { float: right }
       #wrapperlicious {
         max-width: 1000px;
         margin: 0 auto;
@@ -113,7 +113,7 @@
             (<%= link_to 'source' => url_for("/perldoc$path.txt") %>,
             <%= link_to 'CPAN' => $cpan %>)
           </div>
-          <div id="version">v<%= $Mojolicious::VERSION %></div>
+          <div id="mojo-version">v<%= $Mojolicious::VERSION %></div>
         </div>
         <h1><a id="toc">CONTENTS</a></h1>
         <ul>


### PR DESCRIPTION
This removes the collision between the `#version` in the header of the document (with the 'source' and 'CPAN' links) and one generated as part of the POD conversion to HTML.

This can be seen on [Mojolicious::Commands](https://mojolicious.org/perldoc/Mojolicious/Commands) where the heading for the `version` method is floated to the right instead of the version at the top of the page. The TOC link to the `version` method is also broken because of this.