### PR TITLE
Create Fortune plugin and use for introduction title

### DIFF
--- a/fortune.txt
+++ b/fortune.txt
@@ -1,0 +1,27 @@
+100% Egyptian Cotton Websockets
+11,907 commits closer to perfection!
+9 out of 10 penguins recommend Mojolicious!
+Brace Yourself, Mojolicious is coming.
+Bread, Milk, Eggs and Mojo
+Cognito Ergo Mojolicious
+Do not taunt happy fun web framework
+Every deploy, a Moment of Joy.
+Fun is job 1
+Gimme a M, gimme a O, gimme a J, gimme an O
+I am Mojo
+IO, IO, it's off to Loop we go!
+It's as if a million lines of CGI cried out and were suddenly silenced.
+It's not just delicious, it's Mojolicious!
+j($ust).. do it!
+Mojo::IOLoop - There can only be one!
+Mojolicious - It's the bee's knees.
+my $choice = c(@frameworks)->grep(qr/Mojolicious/)->first;
+n { increase_power() } 9000;
+Not legal tender
+One does not simply write a web app without Mojolicious.
+Semper Mojo
+The Mojolicious Look
+There's Perl in my framework!
+We are Mojo
+What are you waiting for?
+Yo, Imma let you finish, but Mojolicious is the best web framework of all time!

--- a/lib/Mojolicious/Plugin/Fortune.pm
+++ b/lib/Mojolicious/Plugin/Fortune.pm
@@ -1,0 +1,15 @@
+package Mojolicious::Plugin::Fortune;
+use Mojo::Base 'Mojolicious::Plugin';
+
+use Mojo::Collection 'c';
+
+sub register {
+  my ($self, $app, $config) = @_;
+
+  my $lines = c(eval { split /\R/, Mojo::File->new($config->{path})->slurp });
+  $lines = c('Missing fortunes. Reward: $1,000!') unless $lines->size;
+
+  $app->helper(fortune => sub { return $lines->[int(rand($lines->size))] });
+}
+
+1;

--- a/mojolicious.pl
+++ b/mojolicious.pl
@@ -7,6 +7,8 @@ BEGIN { unshift @INC, "$FindBin::Bin/lib" }
 # Documentation browser under "/perldoc" (this plugin requires Perl 5.10)
 plugin 'MojoDocs';
 
+plugin 'Fortune' => {path => app->home->child('fortune.txt')};
+
 # Redirect to main site
 hook before_dispatch => sub {
   my $c = shift;

--- a/templates/mojolicious/index.html.ep
+++ b/templates/mojolicious/index.html.ep
@@ -13,7 +13,7 @@
 <div id="wrapperlicious">
   <div class="box spaced" id="introduction">
     <h1>
-      What are you waiting for?
+      %= fortune
     </h1>
     <p>
       Mojolicious is a fresh take on Perl web development, based on years of


### PR DESCRIPTION
Adds a fortune-like choosing of titles for the introduction section on the index page.

Includes all the suggestions from #10 as I am not aware of any objections to any of them, except the "Mojo doesn't socialize" one (sounds pretty negative, but maybe I'm just not getting the reference?).