### PR TITLE
made the sidebar sticky and scrollable

### DIFF
--- a/public/mojodocs.css
+++ b/public/mojodocs.css
@@ -137,6 +137,10 @@ ul { list-style-type: square }
 }
 .mojo-sidebar > ul:first-of-type {
   padding-top: 1rem;
+  position: sticky;
+  overflow: auto;
+  max-height: 110vh;
+  top: -.5rem;
 }
 .mojo-sidebar ul ul li {
   border-left: 1px solid #e1e4e8;


### PR DESCRIPTION
Currently, the sidebar gets pushed up by the footer when you get to the bottom of the page.
I could look more into changing that if that is not the desired behavior.