### PR TITLE
Improve the responsiveness

### DIFF
--- a/public/mojolicious.css
+++ b/public/mojolicious.css
@@ -1,6 +1,9 @@
 body {
   background-color: #fff;
 }
+img {
+  max-width: 100%;
+}
 :not(pre) > code {
   background-color: rgba(0, 0, 0, 0.04);
   border-radius: 3px;

--- a/templates/layouts/mojolicious.html.ep
+++ b/templates/layouts/mojolicious.html.ep
@@ -5,6 +5,7 @@
     <link rel="apple-touch-icon" sizes=""167x167 href="/mojolicious/touch-icon-167x167.png">
     <link rel="apple-touch-icon" sizes=""180x180 href="/mojolicious/touch-icon-180x180.png">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Mojolicious" />
+    <meta name="viewport" content="width=device-width" initial-scale="1" />
     <title><%= title || 'Mojolicious - Perl real-time web framework' %></title>
     %= javascript '/mojolicious/jquery/jquery.js'
     %= javascript '/mojolicious/prettify/run_prettify.js'


### PR DESCRIPTION
Implementing the comment from @smonff and augmenting the `mojo-fun` header image with a media query for screen widths smaller than the image size. Briefly tested with Firefox and Safari responsive design modes.