### PR TITLE
Nested lists responsiveness, plus random fixes

### DIFF
--- a/public/mojodocs.css
+++ b/public/mojodocs.css
@@ -181,8 +181,8 @@ h1:hover .permalink, h2:hover .permalink, h3:hover .permalink, h4:hover .permali
     border-right: 0;
   }
   .mojo-perldoc ul  {
-    padding-left: 0.6rem;
-    font-size: 0.835rem;
+    padding-left: 0.55rem;
+    font-size: 0.725rem;
     line-height: 1.95;
    }
 }

--- a/public/mojodocs.css
+++ b/public/mojodocs.css
@@ -180,4 +180,9 @@ h1:hover .permalink, h2:hover .permalink, h3:hover .permalink, h4:hover .permali
     border-bottom: 1px solid #e1e4e8;
     border-right: 0;
   }
+  .mojo-perldoc ul  {
+    padding-left: 0.6rem;
+    font-size: 0.835rem;
+    line-height: 1.95;
+   }
 }

--- a/templates/layouts/mojolicious.html.ep
+++ b/templates/layouts/mojolicious.html.ep
@@ -1,9 +1,9 @@
 <!doctype html><html>
   <head>
     <link rel="apple-touch-icon" href="/mojolicious/touch-icon.png">
-    <link rel="apple-touch-icon" sizes=""152x152 href="/mojolicious/touch-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes=""167x167 href="/mojolicious/touch-icon-167x167.png">
-    <link rel="apple-touch-icon" sizes=""180x180 href="/mojolicious/touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/mojolicious/touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="167x167" href="/mojolicious/touch-icon-167x167.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/mojolicious/touch-icon-180x180.png">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Mojolicious" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title><%= title || 'Mojolicious - Perl real-time web framework' %></title>

--- a/templates/layouts/mojolicious.html.ep
+++ b/templates/layouts/mojolicious.html.ep
@@ -5,7 +5,7 @@
     <link rel="apple-touch-icon" sizes=""167x167 href="/mojolicious/touch-icon-167x167.png">
     <link rel="apple-touch-icon" sizes=""180x180 href="/mojolicious/touch-icon-180x180.png">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Mojolicious" />
-    <meta name="viewport" content="width=device-width" initial-scale="1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title><%= title || 'Mojolicious - Perl real-time web framework' %></title>
     %= javascript '/mojolicious/jquery/jquery.js'
     %= javascript '/mojolicious/prettify/run_prettify.js'


### PR DESCRIPTION
Since the namespaces can't be wrapped and looks dirty when line-breaked in lists, I decided to try this using a CSS only solution based on media-queries:

- reducing left padding of lists
- reducing the `font-size` of `<ul>`s (sad for consistency, but we cannot do another way. Note the font-size of the lists are now close tot the navigation menu ones)
- increasing `line-height` of lists so despite of the `font-size` decrease, the links are still easy to click (usability matter).

Note that I didn't test that on an Apple device. I only used an Android device and on Firefox / Chrome devices simulators that are obviously useless. 

I fixed two issues in the `<head>`

- the `meta` "viewport" attribut was wrongly declared
- some Apple specific attributes values were set outside of there quotes

 
